### PR TITLE
Fix welcome notification dismissibility

### DIFF
--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -46,7 +46,9 @@ export default function NotificationCard({ notification }: Props) {
   const secondaryActionClasses =
     'inline-flex items-center justify-center gap-2 rounded bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 transition hover:bg-gray-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:outline-gray-600';
 
-  if (notification.id === 'welcome') {
+  const isWelcomeNotification = notification.id === 'welcome';
+
+  if (isWelcomeNotification) {
     actions.push({
       key: 'demo',
       node: (
@@ -105,18 +107,20 @@ export default function NotificationCard({ notification }: Props) {
 
   return (
     <div className="relative overflow-hidden rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition hover:border-blue-200 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-blue-700/60">
-      <button
-        type="button"
-        aria-label={dismissLabel}
-        title={dismissLabel}
-        onClick={() => removeNotification(notification.id)}
-        className="absolute right-4 top-4 rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-      >
-        <X
-          className="h-4 w-4"
-          aria-hidden="true"
-        />
-      </button>
+      {!isWelcomeNotification && (
+        <button
+          type="button"
+          aria-label={dismissLabel}
+          title={dismissLabel}
+          onClick={() => removeNotification(notification.id)}
+          className="absolute right-4 top-4 rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+        >
+          <X
+            className="h-4 w-4"
+            aria-hidden="true"
+          />
+        </button>
+      )}
       <div className="flex items-start gap-4">
         <Icon
           className={`mt-1 h-6 w-6 flex-shrink-0 ${getNotificationIconClasses(notification.type)}`}

--- a/components/NotificationCard/__tests__/NotificationCard.test.tsx
+++ b/components/NotificationCard/__tests__/NotificationCard.test.tsx
@@ -14,6 +14,10 @@ const baseNotification = {
 
 const initialState = useStore.getState();
 const removeNotificationMock = jest.fn();
+const dismissibleNotification = {
+  ...baseNotification,
+  id: 'other-notification',
+};
 
 beforeEach(() => {
   removeNotificationMock.mockReset();
@@ -56,9 +60,19 @@ describe('NotificationCard', () => {
     ).toHaveAttribute('href', '/demo-templates');
   });
 
-  it('allows dismissing the notification', async () => {
-    const user = userEvent.setup();
+  it('keeps the welcome notification fixed', () => {
     render(<NotificationCard notification={baseNotification} />);
+
+    expect(
+      screen.queryByRole('button', {
+        name: /dismiss notification/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('allows dismissing other notifications', async () => {
+    const user = userEvent.setup();
+    render(<NotificationCard notification={dismissibleNotification} />);
 
     const dismissButton = screen.getByRole('button', {
       name: /dismiss notification/i,
@@ -66,6 +80,6 @@ describe('NotificationCard', () => {
 
     await user.click(dismissButton);
 
-    expect(removeNotificationMock).toHaveBeenCalledWith('welcome');
+    expect(removeNotificationMock).toHaveBeenCalledWith('other-notification');
   });
 });


### PR DESCRIPTION
## Summary
- prevent the welcome notification card from rendering the dismiss control
- ensure other notifications remain dismissible through unit coverage

## Testing
- npm run test -- NotificationCard

------
https://chatgpt.com/codex/tasks/task_e_68ddff7c9310832caf498e8a9e50b6d6