### PR TITLE
Fix removal of favorite tags in Add Task form

### DIFF
--- a/components/AddTask/__tests__/AddTask.test.tsx
+++ b/components/AddTask/__tests__/AddTask.test.tsx
@@ -33,6 +33,7 @@ describe('AddTask', () => {
         addTask={jest.fn()}
         tags={[]}
         addTag={jest.fn()}
+        toggleFavoriteTag={jest.fn()}
       />
     );
 

--- a/components/AddTask/__tests__/useAddTask.test.tsx
+++ b/components/AddTask/__tests__/useAddTask.test.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { render, waitFor } from '../../../test/test-utils';
+import { act, render, waitFor } from '../../../test/test-utils';
 import useAddTask from '../useAddTask';
 import { Priority, Tag } from '../../../lib/types';
 
@@ -11,6 +11,7 @@ type AddTaskInput = {
 
 const noopAddTask = (_input: AddTaskInput) => 'new-task';
 const noopAddTag = () => {};
+const noopToggleFavoriteTag = () => {};
 
 function UseAddTaskTest({
   tags,
@@ -23,11 +24,35 @@ function UseAddTaskTest({
     addTask: noopAddTask,
     tags,
     addTag: noopAddTag,
+    toggleFavoriteTag: noopToggleFavoriteTag,
   });
 
   useEffect(() => {
     onTagsChange(state.tags);
   }, [onTagsChange, state.tags]);
+
+  return null;
+}
+
+function RemoveTagTest({
+  tags,
+  toggleFavoriteTag,
+  onReady,
+}: {
+  tags: Tag[];
+  toggleFavoriteTag: (label: string) => void;
+  onReady: (actions: ReturnType<typeof useAddTask>['actions']) => void;
+}) {
+  const { actions } = useAddTask({
+    addTask: noopAddTask,
+    tags,
+    addTag: noopAddTag,
+    toggleFavoriteTag,
+  });
+
+  useEffect(() => {
+    onReady(actions);
+  }, [actions, onReady]);
 
   return null;
 }
@@ -70,5 +95,34 @@ describe('useAddTask', () => {
     await waitFor(() => {
       expect(latestTags).toEqual(['work', 'home']);
     });
+  });
+
+  it('unfavorites tags when they are removed from the form', async () => {
+    const initialTags: Tag[] = [
+      { id: '1', label: 'work', color: '#f00', favorite: true },
+      { id: '2', label: 'home', color: '#0f0', favorite: false },
+    ];
+    const toggleFavoriteTag = jest.fn();
+    let actions: ReturnType<typeof useAddTask>['actions'] | null = null;
+
+    render(
+      <RemoveTagTest
+        tags={initialTags}
+        toggleFavoriteTag={toggleFavoriteTag}
+        onReady={value => {
+          actions = value;
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(actions).not.toBeNull();
+    });
+
+    act(() => {
+      actions?.removeTag('work');
+    });
+
+    expect(toggleFavoriteTag).toHaveBeenCalledWith('work');
   });
 });

--- a/components/AddTask/useAddTask.ts
+++ b/components/AddTask/useAddTask.ts
@@ -11,12 +11,14 @@ export interface UseAddTaskProps {
   }) => string;
   tags: Tag[];
   addTag: (tag: Tag) => void;
+  toggleFavoriteTag: (label: string) => void;
 }
 
 export default function useAddTask({
   addTask,
   tags: existingTags,
   addTag,
+  toggleFavoriteTag,
 }: UseAddTaskProps) {
   const favoriteLabels = existingTags.filter(t => t.favorite).map(t => t.label);
   const [title, setTitle] = useState('');
@@ -105,7 +107,11 @@ export default function useAddTask({
   };
 
   const removeTag = (tagToRemove: string) => {
-    setTags(tags.filter(t => t !== tagToRemove));
+    setTags(prev => prev.filter(t => t !== tagToRemove));
+    const tag = existingTags.find(t => t.label === tagToRemove);
+    if (tag?.favorite) {
+      toggleFavoriteTag(tagToRemove);
+    }
   };
 
   return {

--- a/components/TasksView/TasksView.tsx
+++ b/components/TasksView/TasksView.tsx
@@ -66,6 +66,7 @@ export default function TasksView() {
           addTask={addTask}
           tags={tags}
           addTag={addTag}
+          toggleFavoriteTag={toggleFavoriteTag}
         />
       </div>
       <TagFilter


### PR DESCRIPTION
## Summary
- ensure removing a tag in the Add Task form clears its favorite flag when necessary
- pass the favorite toggle handler into the Add Task hook and update consumers
- expand the Add Task hook tests to cover unfavoriting and adjust component tests for the new prop

## Testing
- npm run test -- useAddTask
- npm run test -- --runTestsByPath components/AddTask/__tests__/AddTask.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68df476b4cfc832cad181d183e2ca1f8