### PR TITLE
Align footer pages layout with demo templates

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -7,54 +7,60 @@ export default function AboutPage() {
   const { t } = useI18n();
 
   return (
-    <main className="mx-auto max-w-2xl space-y-4 px-4 py-16">
-      <h1 className="text-2xl font-bold">{t('aboutPage.title')}</h1>
-      <p>{t('aboutPage.intro')}</p>
-      <ul className="list-disc space-y-1 pl-6">
-        <li>{t('aboutPage.features.freeOpenSource')}</li>
-        <li>{t('aboutPage.features.privacy')}</li>
-        <li>{t('aboutPage.features.fast')}</li>
-        <li>{t('aboutPage.features.personal')}</li>
-        <li>{t('aboutPage.features.export')}</li>
-        <li>{t('aboutPage.features.myTasks')}</li>
-        <li>{t('aboutPage.features.myDay')}</li>
-      </ul>
-      <p>
-        {t('aboutPage.sourceCode')}{' '}
-        <a
-          href="https://github.com/AntonioHCervantes/local-quick-planner"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline hover:no-underline"
-        >
-          GitHub
-        </a>
-        .
-      </p>
-      <p>
-        {t('aboutPage.learnMore')}{' '}
-        <Link
-          href="/faqs"
-          className="underline hover:no-underline"
-        >
-          {t('footer.faqs')}
-        </Link>
-        ,{' '}
-        <Link
-          href="/privacy"
-          className="underline hover:no-underline"
-        >
-          {t('footer.privacy')}
-        </Link>{' '}
-        {t('aboutPage.and')}{' '}
-        <Link
-          href="/terms"
-          className="underline hover:no-underline"
-        >
-          {t('footer.terms')}
-        </Link>
-        .
-      </p>
+    <main className="mx-auto max-w-4xl space-y-8 px-4 py-16">
+      <header className="space-y-4">
+        <h1 className="text-3xl font-bold">{t('aboutPage.title')}</h1>
+        <p className="text-lg text-gray-600 dark:text-gray-300">
+          {t('aboutPage.intro')}
+        </p>
+      </header>
+      <section className="space-y-4">
+        <ul className="list-disc space-y-2 pl-6 text-gray-700 dark:text-gray-200">
+          <li>{t('aboutPage.features.freeOpenSource')}</li>
+          <li>{t('aboutPage.features.privacy')}</li>
+          <li>{t('aboutPage.features.fast')}</li>
+          <li>{t('aboutPage.features.personal')}</li>
+          <li>{t('aboutPage.features.export')}</li>
+          <li>{t('aboutPage.features.myTasks')}</li>
+          <li>{t('aboutPage.features.myDay')}</li>
+        </ul>
+        <p className="text-gray-700 dark:text-gray-200">
+          {t('aboutPage.sourceCode')}{' '}
+          <a
+            href="https://github.com/AntonioHCervantes/local-quick-planner"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:no-underline"
+          >
+            GitHub
+          </a>
+          .
+        </p>
+        <p className="text-gray-700 dark:text-gray-200">
+          {t('aboutPage.learnMore')}{' '}
+          <Link
+            href="/faqs"
+            className="underline hover:no-underline"
+          >
+            {t('footer.faqs')}
+          </Link>
+          ,{' '}
+          <Link
+            href="/privacy"
+            className="underline hover:no-underline"
+          >
+            {t('footer.privacy')}
+          </Link>{' '}
+          {t('aboutPage.and')}{' '}
+          <Link
+            href="/terms"
+            className="underline hover:no-underline"
+          >
+            {t('footer.terms')}
+          </Link>
+          .
+        </p>
+      </section>
     </main>
   );
 }

--- a/app/faqs/page.tsx
+++ b/app/faqs/page.tsx
@@ -19,23 +19,30 @@ export default function FAQsPage() {
   ];
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 px-4 py-16">
-      <h1 className="text-2xl font-bold">{t('faqs.title')}</h1>
-      <Accordion items={faqs} />
-      <div>
-        <h2 className="font-semibold">{t('faqs.supportTitle')}</h2>
-        <p>
-          {t('faqs.support')}{' '}
-          <Link
-            href="https://github.com/AntonioHCervantes/local-quick-planner/issues"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-600 hover:underline dark:text-blue-400"
-          >
-            {t('faqs.supportLink')}
-          </Link>
+    <main className="mx-auto max-w-4xl space-y-8 px-4 py-16">
+      <header className="space-y-4">
+        <h1 className="text-3xl font-bold">{t('faqs.title')}</h1>
+        <p className="text-lg text-gray-600 dark:text-gray-300">
+          {t('faqs.intro')}
         </p>
-      </div>
-    </div>
+      </header>
+      <section className="space-y-6">
+        <Accordion items={faqs} />
+        <div className="space-y-2 text-gray-700 dark:text-gray-200">
+          <h2 className="text-xl font-semibold">{t('faqs.supportTitle')}</h2>
+          <p>
+            {t('faqs.support')}{' '}
+            <Link
+              href="https://github.com/AntonioHCervantes/local-quick-planner/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {t('faqs.supportLink')}
+            </Link>
+          </p>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -7,32 +7,44 @@ export default function PrivacyPage() {
   const { t } = useI18n();
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 px-4 py-16">
-      <h1 className="text-2xl font-bold">{t('privacyPage.title')}</h1>
-      <p>{t('privacyPage.intro')}</p>
-      <h2 className="text-xl font-semibold">
-        {t('privacyPage.localData.title')}
-      </h2>
-      <p>{t('privacyPage.localData.description')}</p>
-      <h2 className="text-xl font-semibold">
-        {t('privacyPage.analytics.title')}
-      </h2>
-      <p>{t('privacyPage.analytics.description')}</p>
-      <h2 className="text-xl font-semibold">
-        {t('privacyPage.contact.title')}
-      </h2>
-      <p>
-        {t('privacyPage.contact.description')}{' '}
-        <Link
-          href="https://github.com/AntonioHCervantes/local-quick-planner/issues"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline hover:no-underline"
-        >
-          {t('faqs.supportLink')}
-        </Link>
-        .
-      </p>
-    </div>
+    <main className="mx-auto max-w-4xl space-y-8 px-4 py-16">
+      <header className="space-y-4">
+        <h1 className="text-3xl font-bold">{t('privacyPage.title')}</h1>
+        <p className="text-lg text-gray-600 dark:text-gray-300">
+          {t('privacyPage.intro')}
+        </p>
+      </header>
+      <section className="space-y-6 text-gray-700 dark:text-gray-200">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            {t('privacyPage.localData.title')}
+          </h2>
+          <p>{t('privacyPage.localData.description')}</p>
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            {t('privacyPage.analytics.title')}
+          </h2>
+          <p>{t('privacyPage.analytics.description')}</p>
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            {t('privacyPage.contact.title')}
+          </h2>
+          <p>
+            {t('privacyPage.contact.description')}{' '}
+            <Link
+              href="https://github.com/AntonioHCervantes/local-quick-planner/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:no-underline"
+            >
+              {t('faqs.supportLink')}
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -7,41 +7,65 @@ export default function TermsPage() {
   const { t } = useI18n();
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 px-4 py-16">
-      <h1 className="text-2xl font-bold">{t('termsPage.title')}</h1>
-      <p>{t('termsPage.intro')}</p>
-      <h2 className="text-xl font-semibold">{t('termsPage.usage.title')}</h2>
-      <p>{t('termsPage.usage.description')}</p>
-      <h2 className="text-xl font-semibold">{t('termsPage.privacy.title')}</h2>
-      <p>
-        {t('termsPage.privacy.description')}{' '}
-        <Link
-          href="/privacy"
-          className="underline hover:no-underline"
-        >
-          {t('footer.privacy')}
-        </Link>
-        .
-      </p>
-      <h2 className="text-xl font-semibold">
-        {t('termsPage.liability.title')}
-      </h2>
-      <p>{t('termsPage.liability.description')}</p>
-      <h2 className="text-xl font-semibold">{t('termsPage.changes.title')}</h2>
-      <p>{t('termsPage.changes.description')}</p>
-      <h2 className="text-xl font-semibold">{t('termsPage.contact.title')}</h2>
-      <p>
-        {t('termsPage.contact.description')}{' '}
-        <Link
-          href="https://github.com/AntonioHCervantes/local-quick-planner/issues"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline hover:no-underline"
-        >
-          {t('faqs.supportLink')}
-        </Link>
-        .
-      </p>
-    </div>
+    <main className="mx-auto max-w-4xl space-y-8 px-4 py-16">
+      <header className="space-y-4">
+        <h1 className="text-3xl font-bold">{t('termsPage.title')}</h1>
+        <p className="text-lg text-gray-600 dark:text-gray-300">
+          {t('termsPage.intro')}
+        </p>
+      </header>
+      <section className="space-y-6 text-gray-700 dark:text-gray-200">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            {t('termsPage.usage.title')}
+          </h2>
+          <p>{t('termsPage.usage.description')}</p>
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            {t('termsPage.privacy.title')}
+          </h2>
+          <p>
+            {t('termsPage.privacy.description')}{' '}
+            <Link
+              href="/privacy"
+              className="underline hover:no-underline"
+            >
+              {t('footer.privacy')}
+            </Link>
+            .
+          </p>
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            {t('termsPage.liability.title')}
+          </h2>
+          <p>{t('termsPage.liability.description')}</p>
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            {t('termsPage.changes.title')}
+          </h2>
+          <p>{t('termsPage.changes.description')}</p>
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            {t('termsPage.contact.title')}
+          </h2>
+          <p>
+            {t('termsPage.contact.description')}{' '}
+            <Link
+              href="https://github.com/AntonioHCervantes/local-quick-planner/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:no-underline"
+            >
+              {t('faqs.supportLink')}
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -272,6 +272,8 @@ const translations: Record<Language, any> = {
     },
     faqs: {
       title: 'Frequently Asked Questions',
+      intro:
+        'Find answers to common questions about how to make the most of CheckPlanner.',
       q1: {
         question: 'What is CheckPlanner?',
         answer:
@@ -634,6 +636,8 @@ const translations: Record<Language, any> = {
     },
     faqs: {
       title: 'Preguntas frecuentes',
+      intro:
+        'Encuentra respuestas a las preguntas más comunes sobre cómo aprovechar CheckPlanner.',
       q1: {
         question: '¿Qué es CheckPlanner?',
         answer:


### PR DESCRIPTION
## Summary
- match the About, FAQs, Privacy, and Terms pages with the Demo Templates layout width and typography
- update supporting copy styles for better readability across those footer-linked pages
- add missing FAQ intro copy in both English and Spanish locales

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df47fedef4832c901c68ca0209b2b3