### PR TITLE
chore: rename project references to checkplanner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ If you have an idea to improve the project, please open an issue with the "enhan
 ### Project Setup
 
 1. Fork the repository.
-2. Clone your fork: `git clone https://github.com/your-username/local-quick-planner.git`
+2. Clone your fork: `git clone https://github.com/your-username/checkplanner.git`
 3. Install dependencies: `npm install`
 4. Run the development server: `npm run dev`
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -27,7 +27,7 @@ export default function AboutPage() {
         <p className="text-gray-700 dark:text-gray-200">
           {t('aboutPage.sourceCode')}{' '}
           <a
-            href="https://github.com/AntonioHCervantes/local-quick-planner"
+            href="https://github.com/AntonioHCervantes/checkplanner"
             target="_blank"
             rel="noopener noreferrer"
             className="underline hover:no-underline"

--- a/app/faqs/page.tsx
+++ b/app/faqs/page.tsx
@@ -33,7 +33,7 @@ export default function FAQsPage() {
           <p>
             {t('faqs.support')}{' '}
             <Link
-              href="https://github.com/AntonioHCervantes/local-quick-planner/issues"
+              href="https://github.com/AntonioHCervantes/checkplanner/issues"
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 hover:underline dark:text-blue-400"

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -34,7 +34,7 @@ export default function PrivacyPage() {
           <p>
             {t('privacyPage.contact.description')}{' '}
             <Link
-              href="https://github.com/AntonioHCervantes/local-quick-planner/issues"
+              href="https://github.com/AntonioHCervantes/checkplanner/issues"
               target="_blank"
               rel="noopener noreferrer"
               className="underline hover:no-underline"

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -55,7 +55,7 @@ export default function TermsPage() {
           <p>
             {t('termsPage.contact.description')}{' '}
             <Link
-              href="https://github.com/AntonioHCervantes/local-quick-planner/issues"
+              href="https://github.com/AntonioHCervantes/checkplanner/issues"
               target="_blank"
               rel="noopener noreferrer"
               className="underline hover:no-underline"

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -16,7 +16,7 @@ export default function Footer() {
           {t('footer.about')}
         </Link>
         <Link
-          href="https://github.com/AntonioHCervantes/local-quick-planner"
+          href="https://github.com/AntonioHCervantes/checkplanner"
           target="_blank"
           rel="noopener noreferrer"
           className="hover:underline"

--- a/components/Footer/__tests__/Footer.test.tsx
+++ b/components/Footer/__tests__/Footer.test.tsx
@@ -7,7 +7,7 @@ describe('Footer', () => {
     expect(screen.getByRole('link', { name: /about/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /open source/i })).toHaveAttribute(
       'href',
-      'https://github.com/AntonioHCervantes/local-quick-planner'
+      'https://github.com/AntonioHCervantes/checkplanner'
     );
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "local-quick-planner",
+  "name": "checkplanner",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "local-quick-planner",
+      "name": "checkplanner",
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "local-quick-planner",
+  "name": "checkplanner",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- rename the package to `checkplanner`
- update documentation, footer links, and tests to point to the CheckPlanner repository

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df48676a74832c966e64f26c2a6f00