### PR TITLE
Suggest configuring a work schedule after task creation

### DIFF
--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -90,14 +90,23 @@ export default function NotificationCard({ notification }: Props) {
   }
 
   if (notification.actionUrl && notification.actionLabelKey) {
+    const isInternalAction = notification.actionUrl.startsWith('/');
+
     actions.push({
       key: 'action',
-      node: (
+      node: isInternalAction ? (
+        <Link
+          href={notification.actionUrl}
+          className={primaryActionClasses}
+        >
+          {t(notification.actionLabelKey)}
+        </Link>
+      ) : (
         <a
           href={notification.actionUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex max-w-full flex-wrap break-words rounded-full bg-blue-600 px-4 py-1.5 text-sm font-medium text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          className={primaryActionClasses}
         >
           {t(notification.actionLabelKey)}
         </a>

--- a/components/NotificationCard/__tests__/NotificationCard.test.tsx
+++ b/components/NotificationCard/__tests__/NotificationCard.test.tsx
@@ -51,6 +51,23 @@ describe('NotificationCard', () => {
     expect(link).toHaveAttribute('href', 'https://example.com');
   });
 
+  it('renders internal action with primary styling in the same tab', () => {
+    render(
+      <NotificationCard
+        notification={{
+          ...dismissibleNotification,
+          actionUrl: '/settings/work-schedule',
+          actionLabelKey: 'notifications.workScheduleSuggestion.cta',
+        }}
+      />
+    );
+
+    const link = screen.getByRole('link', { name: /set work schedule/i });
+    expect(link).toHaveAttribute('href', '/settings/work-schedule');
+    expect(link).not.toHaveAttribute('target');
+    expect(link).toHaveClass('bg-[#57886C]', { exact: false });
+  });
+
   it('shows welcome quick actions', () => {
     render(<NotificationCard notification={baseNotification} />);
 

--- a/components/TaskList/__tests__/TaskList.test.tsx
+++ b/components/TaskList/__tests__/TaskList.test.tsx
@@ -50,7 +50,9 @@ describe('TaskList', () => {
         isFiltering={false}
       />
     );
-    expect(screen.getByText('Add your first task!')).toBeInTheDocument();
+    expect(
+      screen.getByText('Check your plan. Check your day.')
+    ).toBeInTheDocument();
   });
 
   it('shows default empty message while filtering', () => {

--- a/components/WorkScheduleManager/WorkScheduleManager.tsx
+++ b/components/WorkScheduleManager/WorkScheduleManager.tsx
@@ -112,6 +112,62 @@ function findNextReminderWindow(
 
 export default function WorkScheduleManager() {
   useEffect(() => {
+    const SUGGESTION_NOTIFICATION_ID = 'work-schedule-suggestion';
+
+    const hasWorkSchedule = (schedule: Record<Weekday, number[]>): boolean => {
+      return Object.values(schedule ?? {}).some(
+        slots => Array.isArray(slots) && slots.length > 0
+      );
+    };
+
+    const ensureSuggestionVisibility = () => {
+      const state = useStore.getState();
+      const shouldSuggest =
+        state.tasks.length >= 3 && !hasWorkSchedule(state.workSchedule);
+      const existing = state.notifications.find(
+        notification => notification.id === SUGGESTION_NOTIFICATION_ID
+      );
+
+      if (shouldSuggest) {
+        if (!existing) {
+          state.addNotification({
+            id: SUGGESTION_NOTIFICATION_ID,
+            type: 'tip',
+            titleKey: 'notifications.workScheduleSuggestion.title',
+            descriptionKey:
+              'notifications.workScheduleSuggestion.description',
+            actionUrl: '/settings/work-schedule',
+            actionLabelKey: 'notifications.workScheduleSuggestion.cta',
+            read: false,
+            createdAt: new Date().toISOString(),
+          });
+        }
+        return;
+      }
+
+      if (existing) {
+        state.removeNotification(SUGGESTION_NOTIFICATION_ID);
+      }
+    };
+
+    ensureSuggestionVisibility();
+
+    const unsubscribe = useStore.subscribe((state, previousState) => {
+      const tasksChanged = state.tasks !== previousState.tasks;
+      const scheduleChanged =
+        state.workSchedule !== previousState.workSchedule;
+
+      if (tasksChanged || scheduleChanged) {
+        ensureSuggestionVisibility();
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     let destroyed = false;
 

--- a/components/WorkScheduleManager/WorkScheduleManager.tsx
+++ b/components/WorkScheduleManager/WorkScheduleManager.tsx
@@ -134,8 +134,7 @@ export default function WorkScheduleManager() {
             id: SUGGESTION_NOTIFICATION_ID,
             type: 'tip',
             titleKey: 'notifications.workScheduleSuggestion.title',
-            descriptionKey:
-              'notifications.workScheduleSuggestion.description',
+            descriptionKey: 'notifications.workScheduleSuggestion.description',
             actionUrl: '/settings/work-schedule',
             actionLabelKey: 'notifications.workScheduleSuggestion.cta',
             read: false,
@@ -154,8 +153,7 @@ export default function WorkScheduleManager() {
 
     const unsubscribe = useStore.subscribe((state, previousState) => {
       const tasksChanged = state.tasks !== previousState.tasks;
-      const scheduleChanged =
-        state.workSchedule !== previousState.workSchedule;
+      const scheduleChanged = state.workSchedule !== previousState.workSchedule;
 
       if (tasksChanged || scheduleChanged) {
         ensureSuggestionVisibility();

--- a/components/WorkScheduleManager/__tests__/WorkScheduleManager.test.tsx
+++ b/components/WorkScheduleManager/__tests__/WorkScheduleManager.test.tsx
@@ -2,11 +2,70 @@ jest.mock('../../../lib/sounds', () => ({
   playReminderSound: jest.fn(),
 }));
 
-import { render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import WorkScheduleManager from '../WorkScheduleManager';
+import { useStore } from '../../../lib/store';
+import type { Task } from '../../../lib/types';
+
+const initialState = useStore.getState();
+
+const createTasks = (count: number): Task[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `task-${index + 1}`,
+    title: `Task ${index + 1}`,
+    createdAt: new Date(2024, 0, index + 1).toISOString(),
+    listId: 'backlog',
+    plannedFor: null,
+    tags: [],
+    priority: 'medium',
+    repeat: null,
+  }));
+
+const findSuggestion = () =>
+  useStore
+    .getState()
+    .notifications.find(n => n.id === 'work-schedule-suggestion');
 
 describe('WorkScheduleManager', () => {
+  beforeEach(() => {
+    useStore.setState(initialState, true);
+    localStorage.clear();
+  });
+
+  afterAll(() => {
+    useStore.setState(initialState, true);
+    localStorage.clear();
+  });
+
   it('renders without crashing', () => {
     render(<WorkScheduleManager />);
+  });
+
+  it('suggests setting a work schedule when there are at least three tasks', async () => {
+    useStore.setState({ tasks: createTasks(3) });
+
+    render(<WorkScheduleManager />);
+
+    await waitFor(() => {
+      expect(findSuggestion()).toBeDefined();
+    });
+  });
+
+  it('removes the suggestion once the user adds work hours', async () => {
+    useStore.setState({ tasks: createTasks(3) });
+
+    render(<WorkScheduleManager />);
+
+    await waitFor(() => {
+      expect(findSuggestion()).toBeDefined();
+    });
+
+    act(() => {
+      useStore.getState().toggleWorkScheduleSlot('monday', 10, 'add');
+    });
+
+    await waitFor(() => {
+      expect(findSuggestion()).toBeUndefined();
+    });
   });
 });

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -144,6 +144,12 @@ const translations: Record<Language, any> = {
         installInstalled: 'App already installed',
         demoCta: 'Explore demo templates',
       },
+      workScheduleSuggestion: {
+        title: 'Add your work schedule',
+        description:
+          'Save your working hours so you can enable a planning reminder before the end of each workday, plan tomorrow ahead of time, and start the day productively.',
+        cta: 'Set work schedule',
+      },
       workReminder: {
         title: 'Plan tomorrow',
         description:
@@ -509,6 +515,12 @@ const translations: Record<Language, any> = {
           'La instalación solo está disponible en navegadores compatibles. Usa el menú del navegador para añadir CheckPlanner a tu dispositivo.',
         installInstalled: 'La app ya está instalada',
         demoCta: 'Ver plantillas de demostración',
+      },
+      workScheduleSuggestion: {
+        title: 'Añade tu jornada laboral',
+        description:
+          'Guarda tu horario laboral para activar un aviso de planificación antes de que termine cada jornada, preparar el trabajo del día siguiente y empezar de forma productiva.',
+        cta: 'Configurar jornada laboral',
       },
       workReminder: {
         title: 'Planifica el mañana',


### PR DESCRIPTION
## Summary
- add an automatic notification encouraging users without a work schedule to configure it once they have at least three tasks
- localize the new work schedule suggestion copy and call to action in English and Spanish
- cover the notification behavior with tests and align the empty state expectation with the translated text

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68df575e1e78832caa6d8af2ad024c4f