### PR TITLE
Improve progress bar accessibility metadata

### DIFF
--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -37,10 +37,16 @@ export default function ProgressBar({
         <div
           className={`h-full rounded ${colorClass}`}
           style={{ width: `${percent}%` }}
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={percent}
+          aria-label={`${percent}% ${message}`}
         />
       </div>
       <div className="mt-4 flex flex-wrap items-center justify-center gap-2 text-sm text-gray-600 dark:text-gray-400">
         <span>{message}</span>
+        <span className="sr-only">{percent}%</span>
         {showClearAction ? (
           <button
             type="button"


### PR DESCRIPTION
## Summary
- add ARIA progressbar semantics to the progress indicator fill element
- expose the completion percentage to assistive technologies via hidden text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0b07f1864832cb93d37374073f586