### PR TITLE
Improve dialog accessibility and focus handling

### DIFF
--- a/components/AddTask/AddTask.tsx
+++ b/components/AddTask/AddTask.tsx
@@ -4,6 +4,7 @@ import { Plus, Mic } from 'lucide-react';
 import { Priority } from '../../lib/types';
 import { useI18n, Language } from '../../lib/i18n';
 import useAddTask, { UseAddTaskProps } from './useAddTask';
+import useDialogFocusTrap from '../../lib/useDialogFocusTrap';
 
 export default function AddTask(props: UseAddTaskProps) {
   const { state, actions } = useAddTask(props);
@@ -25,6 +26,14 @@ export default function AddTask(props: UseAddTaskProps) {
   const titleRef = useRef(title);
   const initialTitleRef = useRef('');
   const tagInputRef = useRef<HTMLInputElement>(null);
+  const voiceWarningRef = useRef<HTMLDivElement | null>(null);
+  const voiceWarningCloseButtonRef = useRef<HTMLButtonElement | null>(null);
+  const {
+    onFocusStartGuard: onVoiceWarningFocusStartGuard,
+    onFocusEndGuard: onVoiceWarningFocusEndGuard,
+  } = useDialogFocusTrap(showVoiceWarning, voiceWarningRef, {
+    initialFocusRef: voiceWarningCloseButtonRef,
+  });
 
   const getTagColor = (tagLabel: string) => {
     const tag = existingTags.find(t => t.label === tagLabel);
@@ -187,14 +196,40 @@ export default function AddTask(props: UseAddTaskProps) {
       </form>
       {showVoiceWarning && (
         <div className="fixed inset-0 flex items-center justify-center bg-black/50">
-          <div className="w-full max-w-sm rounded bg-gray-900 p-6 text-center text-gray-100">
-            <p className="mb-4">{t('addTask.voiceInputNoText')}</p>
+          <div
+            ref={voiceWarningRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="voice-warning-title"
+            className="w-full max-w-sm rounded bg-gray-900 p-6 text-center text-gray-100"
+          >
+            <span
+              tabIndex={0}
+              aria-hidden="true"
+              data-focus-guard
+              onFocus={onVoiceWarningFocusStartGuard}
+              className="sr-only"
+            />
+            <h2
+              id="voice-warning-title"
+              className="mb-4 text-lg font-semibold"
+            >
+              {t('addTask.voiceInputNoText')}
+            </h2>
             <button
+              ref={voiceWarningCloseButtonRef}
               onClick={() => setShowVoiceWarning(false)}
               className="rounded bg-gray-700 px-3 py-1 hover:bg-gray-600 focus:bg-gray-600"
             >
               {t('actions.close')}
             </button>
+            <span
+              tabIndex={0}
+              aria-hidden="true"
+              data-focus-guard
+              onFocus={onVoiceWarningFocusEndGuard}
+              className="sr-only"
+            />
           </div>
         </div>
       )}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -20,6 +20,7 @@ import { Language, LANGUAGES } from '../../lib/i18n';
 import { getNotificationIconClasses } from '../../lib/notifications';
 import Icon from '../Icon/Icon';
 import useHeader from './useHeader';
+import useDialogFocusTrap from '../../lib/useDialogFocusTrap';
 
 export default function Header() {
   const { state, actions } = useHeader();
@@ -50,6 +51,14 @@ export default function Header() {
   const headerRef = useRef<HTMLElement | null>(null);
   const bellRef = useRef<HTMLAnchorElement | null>(null);
   const langMenuRef = useRef<HTMLDivElement | null>(null);
+  const confirmDialogRef = useRef<HTMLDivElement | null>(null);
+  const confirmCancelButtonRef = useRef<HTMLButtonElement | null>(null);
+  const {
+    onFocusStartGuard: onConfirmFocusStartGuard,
+    onFocusEndGuard: onConfirmFocusEndGuard,
+  } = useDialogFocusTrap(showConfirm, confirmDialogRef, {
+    initialFocusRef: confirmCancelButtonRef,
+  });
   const [popoverPosition, setPopoverPosition] = useState<{
     top: number;
     right: number;
@@ -398,10 +407,29 @@ export default function Header() {
       )}
       {showConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="w-full max-w-sm rounded bg-gray-900 p-6 text-center text-gray-100">
-            <p className="mb-4">{t('confirmDelete.message')}</p>
+          <div
+            ref={confirmDialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="confirm-delete-title"
+            className="w-full max-w-sm rounded bg-gray-900 p-6 text-center text-gray-100"
+          >
+            <span
+              tabIndex={0}
+              aria-hidden="true"
+              data-focus-guard
+              onFocus={onConfirmFocusStartGuard}
+              className="sr-only"
+            />
+            <h2
+              id="confirm-delete-title"
+              className="mb-4 text-lg font-semibold"
+            >
+              {t('confirmDelete.message')}
+            </h2>
             <div className="flex justify-center gap-2">
               <button
+                ref={confirmCancelButtonRef}
                 onClick={() => setShowConfirm(false)}
                 className="rounded bg-gray-700 px-3 py-1 hover:bg-gray-600 focus:bg-gray-600"
               >
@@ -414,6 +442,13 @@ export default function Header() {
                 {t('confirmDelete.delete')}
               </button>
             </div>
+            <span
+              tabIndex={0}
+              aria-hidden="true"
+              data-focus-guard
+              onFocus={onConfirmFocusEndGuard}
+              className="sr-only"
+            />
           </div>
         </div>
       )}

--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -18,6 +18,7 @@ import { CSS } from '@dnd-kit/utilities';
 import LinkifiedText from '../LinkifiedText/LinkifiedText';
 import Link from '../Link/Link';
 import { useStore } from '../../lib/store';
+import useDialogFocusTrap from '../../lib/useDialogFocusTrap';
 
 const BASE_TOOLTIP_OFFSET = -72;
 
@@ -55,6 +56,14 @@ export default function TaskItem({
   const [showRecurringOptions, setShowRecurringOptions] = useState(false);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const [tooltipShift, setTooltipShift] = useState(0);
+  const repeatDialogRef = useRef<HTMLDivElement | null>(null);
+  const firstRepeatDayRef = useRef<HTMLInputElement | null>(null);
+  const {
+    onFocusStartGuard: onRepeatFocusStartGuard,
+    onFocusEndGuard: onRepeatFocusEndGuard,
+  } = useDialogFocusTrap(showRecurringOptions, repeatDialogRef, {
+    initialFocusRef: firstRepeatDayRef,
+  });
 
   useEffect(() => {
     if (!showMyDayHelp) {
@@ -105,10 +114,18 @@ export default function TaskItem({
       setShowRecurringOptions(false);
     };
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setShowRecurringOptions(false);
+      }
+    };
+
     document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [showRecurringOptions]);
 
@@ -145,6 +162,17 @@ export default function TaskItem({
   const weeklyRepeat = task.repeat?.frequency === 'weekly' ? task.repeat : null;
   const selectedDays: Weekday[] = weeklyRepeat ? weeklyRepeat.days : [];
   const repeatPanelId = `task-repeat-${task.id}`;
+  const repeatDialogTitleId = `${repeatPanelId}-title`;
+  const repeatDialogLimitedHintId = `${repeatPanelId}-limited-hint`;
+  const repeatDialogAutoAddHintId = `${repeatPanelId}-auto-hint`;
+  const repeatDialogDescribedBy = [
+    showLimitedWeekdaysHint ? repeatDialogLimitedHintId : null,
+    repeatDialogAutoAddHintId,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const repeatDialogAriaDescribedBy =
+    repeatDialogDescribedBy.length > 0 ? repeatDialogDescribedBy : undefined;
   const repeatButtonLabel = selectedDays.length
     ? t('taskItem.recurring.buttonWithDays').replace(
         '{days}',
@@ -170,103 +198,133 @@ export default function TaskItem({
       className="relative flex w-full flex-col gap-2"
       data-repeat-actions="true"
     >
-      <div className="flex items-center justify-end gap-2">
-        <div className="relative">
-          <button
-            type="button"
-            onClick={() => setShowRecurringOptions(prev => !prev)}
-            aria-expanded={showRecurringOptions}
-            aria-controls={repeatPanelId}
-            aria-label={repeatButtonLabel}
-            title={repeatButtonLabel}
-            className={`flex items-center justify-center rounded bg-transparent p-1 text-black focus-visible:ring dark:text-white ${
-              showRecurringOptions || selectedDays.length > 0
-                ? 'text-[#57886C]'
-                : ''
-            }`}
-          >
-            <RotateCcw className="h-4 w-4" />
-          </button>
-        </div>
-        <div className="relative flex items-center">
-          <button
-            onClick={() => toggleMyDay(task.id)}
-            aria-label={
-              task.plannedFor
-                ? t('taskItem.removeMyDay')
-                : t('taskItem.addMyDay')
-            }
-            title={
-              task.plannedFor
-                ? t('taskItem.removeMyDay')
-                : t('taskItem.addMyDay')
-            }
-            className={`flex items-center justify-center rounded bg-transparent p-1 text-black focus:ring dark:text-white ${
-              showHelp
-                ? 'animate-pulse ring-2 ring-[#57886C] ring-offset-2 ring-offset-gray-100 dark:ring-offset-gray-900'
-                : ''
-            }`}
-          >
-            {task.plannedFor ? (
-              <CalendarX className="h-4 w-4" />
-            ) : (
-              <CalendarPlus className="h-4 w-4" />
-            )}
-          </button>
-          {showHelp && (
-            <div
-              ref={tooltipRef}
-              className="absolute left-1/2 top-full z-30 mt-4 w-72 max-w-xs rounded-3xl border border-slate-200/80 bg-white/95 px-5 py-4 text-[15px] text-slate-700 shadow-2xl backdrop-blur-sm dark:border-gray-700/70 dark:bg-gray-900/95 dark:text-gray-100"
-              style={{
-                transform: `translateX(calc(-50% + ${tooltipShift + BASE_TOOLTIP_OFFSET}px))`,
-              }}
+      <div aria-hidden={showRecurringOptions ? 'true' : undefined}>
+        <div className="flex items-center justify-end gap-2">
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setShowRecurringOptions(prev => !prev)}
+              aria-expanded={showRecurringOptions}
+              aria-controls={repeatPanelId}
+              aria-label={repeatButtonLabel}
+              title={repeatButtonLabel}
+              className={`flex items-center justify-center rounded bg-transparent p-1 text-black focus-visible:ring dark:text-white ${
+                showRecurringOptions || selectedDays.length > 0
+                  ? 'text-[#57886C]'
+                  : ''
+              }`}
             >
-              <div className="flex items-start gap-3">
-                <HelpCircle className="mt-[2px] h-5 w-5 flex-shrink-0 text-[#57886C]" />
-                <span className="flex-1 leading-relaxed">
-                  {t('taskItem.myDayHelp')}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => onCloseMyDayHelp?.()}
-                  aria-label={t('actions.close')}
-                  className="ml-2 rounded-full p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#57886C] dark:text-gray-300 dark:hover:bg-gray-700/70 dark:hover:text-white"
-                >
-                  ×
-                </button>
+              <RotateCcw className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="relative flex items-center">
+            <button
+              onClick={() => toggleMyDay(task.id)}
+              aria-label={
+                task.plannedFor
+                  ? t('taskItem.removeMyDay')
+                  : t('taskItem.addMyDay')
+              }
+              title={
+                task.plannedFor
+                  ? t('taskItem.removeMyDay')
+                  : t('taskItem.addMyDay')
+              }
+              className={`flex items-center justify-center rounded bg-transparent p-1 text-black focus:ring dark:text-white ${
+                showHelp
+                  ? 'animate-pulse ring-2 ring-[#57886C] ring-offset-2 ring-offset-gray-100 dark:ring-offset-gray-900'
+                  : ''
+              }`}
+            >
+              {task.plannedFor ? (
+                <CalendarX className="h-4 w-4" />
+              ) : (
+                <CalendarPlus className="h-4 w-4" />
+              )}
+            </button>
+            {showHelp && (
+              <div
+                ref={tooltipRef}
+                className="absolute left-1/2 top-full z-30 mt-4 w-72 max-w-xs rounded-3xl border border-slate-200/80 bg-white/95 px-5 py-4 text-[15px] text-slate-700 shadow-2xl backdrop-blur-sm dark:border-gray-700/70 dark:bg-gray-900/95 dark:text-gray-100"
+                style={{
+                  transform: `translateX(calc(-50% + ${tooltipShift + BASE_TOOLTIP_OFFSET}px))`,
+                }}
+              >
+                <div className="flex items-start gap-3">
+                  <HelpCircle className="mt-[2px] h-5 w-5 flex-shrink-0 text-[#57886C]" />
+                  <span className="flex-1 leading-relaxed">
+                    {t('taskItem.myDayHelp')}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onCloseMyDayHelp?.()}
+                    aria-label={t('actions.close')}
+                    className="ml-2 rounded-full p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#57886C] dark:text-gray-300 dark:hover:bg-gray-700/70 dark:hover:text-white"
+                  >
+                    ×
+                  </button>
+                </div>
               </div>
-            </div>
-          )}
+            )}
+          </div>
+          <button
+            onClick={() => removeTask(task.id)}
+            aria-label={t('taskItem.deleteTask')}
+            title={t('taskItem.deleteTask')}
+            className="flex items-center justify-center rounded bg-transparent p-1 text-black focus:ring dark:text-white"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
         </div>
-        <button
-          onClick={() => removeTask(task.id)}
-          aria-label={t('taskItem.deleteTask')}
-          title={t('taskItem.deleteTask')}
-          className="flex items-center justify-center rounded bg-transparent p-1 text-black focus:ring dark:text-white"
-        >
-          <Trash2 className="h-4 w-4" />
-        </button>
+        {repeatStatusVisible && (
+          <p className="text-right text-xs font-medium text-[#57886C]">
+            {repeatButtonLabel}
+          </p>
+        )}
       </div>
-      {repeatStatusVisible && (
-        <p className="text-right text-xs font-medium text-[#57886C]">
-          {repeatButtonLabel}
-        </p>
-      )}
       {showRecurringOptions && (
         <div
           id={repeatPanelId}
-          className="absolute right-0 top-full z-30 mt-2 w-64 space-y-3 rounded border border-gray-300 bg-white p-3 text-xs text-gray-700 shadow-lg dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+          ref={repeatDialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={repeatDialogTitleId}
+          aria-describedby={repeatDialogAriaDescribedBy}
+          className="absolute right-0 top-full z-30 mt-2 w-64 space-y-3 rounded border border-gray-300 bg-white p-3 text-xs text-gray-700 shadow-lg focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
         >
-          <div className="space-y-1">
-            <p>{t('taskItem.recurring.description')}</p>
-            {showLimitedWeekdaysHint && (
-              <p className="text-[11px] text-gray-500 dark:text-gray-400">
-                {t('taskItem.recurring.limitedBySchedule')}
-              </p>
-            )}
+          <span
+            tabIndex={0}
+            aria-hidden="true"
+            data-focus-guard
+            onFocus={onRepeatFocusStartGuard}
+            className="sr-only"
+          />
+          <div className="flex items-start justify-between gap-2">
+            <h2
+              id={repeatDialogTitleId}
+              className="text-xs font-semibold text-gray-900 dark:text-gray-100"
+            >
+              {t('taskItem.recurring.description')}
+            </h2>
+            <button
+              type="button"
+              onClick={() => setShowRecurringOptions(false)}
+              aria-label={t('actions.close')}
+              className="-mt-1 -mr-1 rounded p-1 text-gray-500 transition hover:bg-gray-100 hover:text-gray-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#57886C] dark:text-gray-300 dark:hover:bg-gray-800/80 dark:hover:text-white"
+            >
+              ×
+            </button>
           </div>
+          {showLimitedWeekdaysHint && (
+            <p
+              id={repeatDialogLimitedHintId}
+              className="text-[11px] text-gray-500 dark:text-gray-400"
+            >
+              {t('taskItem.recurring.limitedBySchedule')}
+            </p>
+          )}
           <div className="flex flex-wrap gap-2">
-            {availableWeekdays.map(day => {
+            {availableWeekdays.map((day, index) => {
               const checked = selectedDays.includes(day);
               return (
                 <label
@@ -279,6 +337,7 @@ export default function TaskItem({
                 >
                   <input
                     type="checkbox"
+                    ref={index === 0 ? firstRepeatDayRef : undefined}
                     checked={checked}
                     onChange={() => handleToggleRepeatDay(day)}
                     className="h-3.5 w-3.5"
@@ -288,7 +347,10 @@ export default function TaskItem({
               );
             })}
           </div>
-          <p className="text-[11px] text-gray-500 dark:text-gray-400">
+          <p
+            id={repeatDialogAutoAddHintId}
+            className="text-[11px] text-gray-500 dark:text-gray-400"
+          >
             {t('taskItem.recurring.autoAddHint')}
           </p>
           {selectedDays.length > 0 && (
@@ -300,6 +362,13 @@ export default function TaskItem({
               {t('taskItem.recurring.remove')}
             </button>
           )}
+          <span
+            tabIndex={0}
+            aria-hidden="true"
+            data-focus-guard
+            onFocus={onRepeatFocusEndGuard}
+            className="sr-only"
+          />
         </div>
       )}
     </div>

--- a/components/WelcomeModal/WelcomeModal.tsx
+++ b/components/WelcomeModal/WelcomeModal.tsx
@@ -1,16 +1,26 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Check } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useStore } from '../../lib/store';
 import { useI18n } from '../../lib/i18n';
+import useDialogFocusTrap from '../../lib/useDialogFocusTrap';
 
 export default function WelcomeModal() {
   const [open, setOpen] = useState(false);
   const tasks = useStore(state => state.tasks);
   const router = useRouter();
   const { t } = useI18n();
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const primaryButtonRef = useRef<HTMLButtonElement | null>(null);
+  const { onFocusStartGuard, onFocusEndGuard } = useDialogFocusTrap(
+    open,
+    dialogRef,
+    {
+      initialFocusRef: primaryButtonRef,
+    }
+  );
 
   useEffect(() => {
     const seen = localStorage.getItem('welcomeSeen');
@@ -29,8 +39,26 @@ export default function WelcomeModal() {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-md rounded-lg bg-white p-6 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100">
-        <h2 className="mb-4 text-2xl font-bold">{t('welcomeModal.title')}</h2>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="welcome-modal-title"
+        className="w-full max-w-md rounded-lg bg-white p-6 text-gray-900 shadow-lg dark:bg-gray-800 dark:text-gray-100"
+      >
+        <span
+          tabIndex={0}
+          aria-hidden="true"
+          data-focus-guard
+          onFocus={onFocusStartGuard}
+          className="sr-only"
+        />
+        <h2
+          id="welcome-modal-title"
+          className="mb-4 text-2xl font-bold"
+        >
+          {t('welcomeModal.title')}
+        </h2>
         <ul className="mb-6 space-y-2">
           {[1, 2, 3, 4, 5].map(n => (
             <li
@@ -43,11 +71,19 @@ export default function WelcomeModal() {
           ))}
         </ul>
         <button
+          ref={primaryButtonRef}
           onClick={handleClose}
           className="w-full rounded bg-[#57886C] px-4 py-2 text-white hover:brightness-110 focus:ring"
         >
           {t('welcomeModal.cta')}
         </button>
+        <span
+          tabIndex={0}
+          aria-hidden="true"
+          data-focus-guard
+          onFocus={onFocusEndGuard}
+          className="sr-only"
+        />
       </div>
     </div>
   );

--- a/lib/useDialogFocusTrap.ts
+++ b/lib/useDialogFocusTrap.ts
@@ -7,7 +7,7 @@ type UseDialogFocusTrapOptions = {
   /**
    * Optional ref for the element that should receive focus when the dialog opens.
    */
-  initialFocusRef?: RefObject<HTMLElement>;
+  initialFocusRef?: RefObject<HTMLElement | null>;
 };
 
 const getFocusableElements = (container: HTMLElement) => {
@@ -25,7 +25,7 @@ const getFocusableElements = (container: HTMLElement) => {
 
 export default function useDialogFocusTrap(
   isOpen: boolean,
-  dialogRef: RefObject<HTMLElement>,
+  dialogRef: RefObject<HTMLElement | null>,
   options: UseDialogFocusTrapOptions = {}
 ) {
   const previouslyFocusedElement = useRef<HTMLElement | null>(null);

--- a/lib/useDialogFocusTrap.ts
+++ b/lib/useDialogFocusTrap.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]):not([tabindex="-1"]), textarea:not([disabled]):not([tabindex="-1"]), input:not([disabled]):not([tabindex="-1"]), select:not([disabled]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
+
+type UseDialogFocusTrapOptions = {
+  /**
+   * Optional ref for the element that should receive focus when the dialog opens.
+   */
+  initialFocusRef?: RefObject<HTMLElement>;
+};
+
+const getFocusableElements = (container: HTMLElement) => {
+  const focusable = Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+  ).filter(
+    element =>
+      !element.hasAttribute('disabled') &&
+      element.getAttribute('aria-hidden') !== 'true' &&
+      !element.hasAttribute('data-focus-guard')
+  );
+
+  return focusable;
+};
+
+export default function useDialogFocusTrap(
+  isOpen: boolean,
+  dialogRef: RefObject<HTMLElement>,
+  options: UseDialogFocusTrapOptions = {}
+) {
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null);
+  const { initialFocusRef } = options;
+
+  const focusFirstElement = useCallback(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+
+    if (initialFocusRef?.current) {
+      initialFocusRef.current.focus();
+      return;
+    }
+
+    const focusable = getFocusableElements(dialog);
+    const first = focusable[0];
+
+    if (first) {
+      first.focus();
+      return;
+    }
+
+    if (!dialog.hasAttribute('tabindex')) {
+      dialog.setAttribute('tabindex', '-1');
+    }
+    dialog.focus();
+  }, [dialogRef, initialFocusRef]);
+
+  const focusLastElement = useCallback(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+
+    const focusable = getFocusableElements(dialog);
+    const last = focusable[focusable.length - 1];
+
+    if (last) {
+      last.focus();
+      return;
+    }
+
+    dialog.focus();
+  }, [dialogRef]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    previouslyFocusedElement.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    const frame = window.requestAnimationFrame(() => {
+      focusFirstElement();
+    });
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || !dialogRef.current) {
+        return;
+      }
+
+      const focusable = getFocusableElements(dialogRef.current);
+
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialogRef.current.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const { activeElement } = document;
+
+      if (event.shiftKey) {
+        if (activeElement === first || activeElement === dialogRef.current) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.removeEventListener('keydown', handleKeyDown);
+      if (previouslyFocusedElement.current) {
+        previouslyFocusedElement.current.focus();
+      }
+    };
+  }, [dialogRef, focusFirstElement, isOpen]);
+
+  const handleFocusStart = useCallback(() => {
+    focusLastElement();
+  }, [focusLastElement]);
+
+  const handleFocusEnd = useCallback(() => {
+    focusFirstElement();
+  }, [focusFirstElement]);
+
+  return {
+    onFocusStartGuard: handleFocusStart,
+    onFocusEndGuard: handleFocusEnd,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable focus trap hook to manage modal focus and restore the trigger
- update confirmation, welcome, and voice warning dialogs with proper ARIA semantics and focus guards
- ensure modals announce their headings and focus the primary action on open

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0b088b7e8832cab0c5bfe333ea4ac