### PR TITLE
fix: preserve welcome notification after template import

### DIFF
--- a/lib/__tests__/importData.test.ts
+++ b/lib/__tests__/importData.test.ts
@@ -1,0 +1,51 @@
+import { DEMO_TEMPLATES } from '../demoTemplates';
+import { useStore } from '../store';
+import type { Notification, PersistedState } from '../types';
+
+describe('importData', () => {
+  beforeEach(() => {
+    useStore.getState().clearAll();
+  });
+
+  it('re-adds the welcome notification when the imported data lacks it', () => {
+    const templateState = DEMO_TEMPLATES[0].createState();
+    expect(templateState.notifications).toHaveLength(0);
+
+    useStore.getState().importData(templateState);
+
+    const notifications = useStore.getState().notifications;
+    const welcome = notifications.find(
+      notification => notification.id === 'welcome'
+    );
+
+    expect(welcome).toBeDefined();
+    expect(welcome?.titleKey).toBe('notifications.welcome.title');
+  });
+
+  it('keeps an existing welcome notification without duplicating it', () => {
+    const templateState = DEMO_TEMPLATES[0].createState();
+    const existingWelcome: Notification = {
+      id: 'welcome',
+      type: 'info',
+      titleKey: 'notifications.welcome.title',
+      descriptionKey: 'notifications.welcome.description',
+      read: true,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    };
+    const stateWithWelcome: PersistedState = {
+      ...templateState,
+      notifications: [existingWelcome],
+    };
+
+    useStore.getState().importData(stateWithWelcome);
+
+    const notifications = useStore.getState().notifications;
+    const welcomeNotifications = notifications.filter(
+      notification => notification.id === 'welcome'
+    );
+
+    expect(welcomeNotifications).toHaveLength(1);
+    expect(welcomeNotifications[0].createdAt).toBe(existingWelcome.createdAt);
+    expect(welcomeNotifications[0].read).toBe(true);
+  });
+});

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -165,6 +165,27 @@ const DAY_FROM_INDEX: Record<number, Weekday> = {
   6: 'saturday',
 };
 
+const createWelcomeNotification = () => ({
+  id: 'welcome',
+  type: 'info' as const,
+  titleKey: 'notifications.welcome.title',
+  descriptionKey: 'notifications.welcome.description',
+  read: false,
+  createdAt: new Date().toISOString(),
+});
+
+const ensureWelcomeNotification = (
+  notifications: Notification[] | undefined
+): Notification[] => {
+  if (!notifications || notifications.length === 0) {
+    return [createWelcomeNotification()];
+  }
+
+  return notifications.some(notification => notification.id === 'welcome')
+    ? notifications
+    : [...notifications, createWelcomeNotification()];
+};
+
 const defaultState: PersistedState = {
   tasks: [],
   lists: defaultLists,
@@ -181,16 +202,7 @@ const defaultState: PersistedState = {
     'day-doing': [],
     'day-done': [],
   },
-  notifications: [
-    {
-      id: 'welcome',
-      type: 'info',
-      titleKey: 'notifications.welcome.title',
-      descriptionKey: 'notifications.welcome.description',
-      read: false,
-      createdAt: new Date().toISOString(),
-    },
-  ],
+  notifications: [createWelcomeNotification()],
   timers: {},
   mainMyDayTaskId: null,
   workSchedule: createEmptyWorkSchedule(),
@@ -849,6 +861,7 @@ export const useStore = create<Store>((set, get) => ({
     const sanitized: PersistedState = {
       ...defaultState,
       ...data,
+      notifications: ensureWelcomeNotification(data.notifications),
       timers: data.timers ?? {},
       mainMyDayTaskId: data.mainMyDayTaskId ?? null,
       workSchedule: sanitizeWorkSchedule(data.workSchedule),


### PR DESCRIPTION
## Summary
- ensure the welcome notification is recreated if missing when importing data and reuse a helper for the default state
- add regression tests that cover importing demo templates with and without an existing welcome notification

## Testing
- npm run lint
- npm run typecheck
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e33d8bfe48832ca07241ea7e9c0995