### PR TITLE
feat: focus weekly repeat options on open

### DIFF
--- a/components/TaskItem/TaskItem.tsx
+++ b/components/TaskItem/TaskItem.tsx
@@ -66,6 +66,20 @@ export default function TaskItem({
   });
 
   useEffect(() => {
+    if (!showRecurringOptions) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      firstRepeatDayRef.current?.focus();
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [showRecurringOptions]);
+
+  useEffect(() => {
     if (!showMyDayHelp) {
       setTooltipShift(0);
       return;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/jest": "^30.0.0",
         "@types/node": "24.2.1",
         "@types/react": "19.1.9",
+        "@types/react-dom": "^19.1.5",
         "autoprefixer": "^10.4.14",
         "eslint": "^8.57.0",
         "eslint-config-next": "15.5.4",
@@ -2509,6 +2510,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
+      "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
       }
     },
     "node_modules/@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "24.2.1",
     "@types/react": "19.1.9",
+    "@types/react-dom": "^19.1.5",
     "autoprefixer": "^10.4.14",
     "eslint": "^8.57.0",
     "eslint-config-next": "15.5.4",


### PR DESCRIPTION
## Summary
- ensure the weekly repeat dialog directs focus to the weekday checkboxes when it opens so keyboard users can select days immediately

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e346f2df40832cba3496eb88b052cd