### PR TITLE
feat: add demo templates link to empty my tasks view

### DIFF
--- a/components/TaskList/TaskList.tsx
+++ b/components/TaskList/TaskList.tsx
@@ -1,4 +1,5 @@
 'use client';
+import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { DndContext } from '@dnd-kit/core';
 import {
@@ -143,6 +144,14 @@ export default function TaskList({
                 {t(emptyMessageKey)}
               </p>
               <NoTasksIllustration className="mt-2 text-gray-400 dark:text-gray-500" />
+              {!hasTasks && !isFiltering && (
+                <Link
+                  href="/demo-templates"
+                  className="mt-4 inline-flex items-center rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+                >
+                  {t('taskList.exploreDemoTemplates')}
+                </Link>
+              )}
             </div>
           )}
         </div>

--- a/components/TaskList/__tests__/TaskList.test.tsx
+++ b/components/TaskList/__tests__/TaskList.test.tsx
@@ -53,6 +53,9 @@ describe('TaskList', () => {
     expect(
       screen.getByText('Check your plan. Check your day.')
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Explore demo templates' })
+    ).toHaveAttribute('href', '/demo-templates');
   });
 
   it('shows default empty message while filtering', () => {
@@ -64,5 +67,8 @@ describe('TaskList', () => {
       />
     );
     expect(screen.getByText('No tasks')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Explore demo templates' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -110,6 +110,7 @@ const translations: Record<Language, any> = {
     taskList: {
       noTasks: 'No tasks',
       noTasksIntro: 'Check your plan. Check your day.',
+      exploreDemoTemplates: 'Explore demo templates',
     },
     dnd: {
       keyboardInstructions:
@@ -482,6 +483,7 @@ const translations: Record<Language, any> = {
     taskList: {
       noTasks: 'No hay tareas',
       noTasksIntro: 'Check your plan. Check your day.',
+      exploreDemoTemplates: 'Explorar plantillas demo',
     },
     dnd: {
       keyboardInstructions:


### PR DESCRIPTION
## Summary
- add a secondary call-to-action in the My Tasks empty state that links to the demo templates view
- extend translations with the new demo templates exploration label
- cover the empty state navigation affordance with unit tests

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e34dbd226c832c90e279ae95716e8c