### PR TITLE
docs: document public checkplanner.com domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # CheckPlanner
 
-CheckPlanner is a simple, fast, and free tool to organize your tasks and
-boost your productivity.
+CheckPlanner is a simple, fast, and free tool to organize your tasks and boost
+your productivity.
 
 Your privacy is paramount: all data is stored locally in your browser's
 `localStorage`, ensuring your tasks stay on your machine.
+
+## 🌐 Live App
+
+Start planning right away at [checkplanner.com](https://www.checkplanner.com).
+The production site is the same PWA experience described in this
+repository—installable, offline-ready, and privacy-first.
 
 ## ✨ Features
 
@@ -30,7 +36,7 @@ Your privacy is paramount: all data is stored locally in your browser's
 
 1. Clone the repository:
    ```bash
-  git clone https://github.com/your-username/checkplanner.git
+   git clone https://github.com/your-username/checkplanner.git
    ```
 2. Install dependencies:
    ```bash
@@ -41,7 +47,9 @@ Your privacy is paramount: all data is stored locally in your browser's
    npm run dev
    ```
 
-Then open http://localhost:3000 in your browser.
+Then open http://localhost:3000 in your browser. Prefer the production build at
+[checkplanner.com](https://www.checkplanner.com) when you just want to use the
+planner without running it locally.
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,20 @@ repository—installable, offline-ready, and privacy-first.
 ## 🚀 Quick Start
 
 1. Clone the repository:
+
    ```bash
-   git clone https://github.com/your-username/checkplanner.git
+   git clone https://github.com/checkplanner/checkplanner.git
+   cd checkplanner
    ```
+
 2. Install dependencies:
+
    ```bash
    npm install
    ```
+
 3. Run the development server:
+
    ```bash
    npm run dev
    ```

--- a/docs/PROJECT_GUIDE.md
+++ b/docs/PROJECT_GUIDE.md
@@ -3,14 +3,14 @@
 ## Purpose of this document
 
 Use this handbook as the single source of truth when you collaborate with the
-CheckPlanner codebase. It summarizes the architecture, data flows,
-quality gates, and conventions that every agent must follow to keep the project
-healthy and scalable.
+CheckPlanner codebase. It summarizes the architecture, data flows, quality
+gates, and conventions that every agent must follow to keep the project healthy
+and scalable.
 
 ## How to use this guide
 
-1. Keep this guide in the `docs/` directory so every collaborator and
-   automation tool can locate it instantly.
+1. Keep this guide in the `docs/` directory so every collaborator and automation
+   tool can locate it instantly.
 2. Ensure the sections remain focused on the information agents need to work
    effectively—project overview, build and test commands, code style rules,
    testing guidance, security considerations, and any other context that aids
@@ -21,6 +21,10 @@ healthy and scalable.
    contributors join.
 
 ## Project at a glance
+
+- **Public domain:** [checkplanner.com](https://www.checkplanner.com) hosts the
+  live PWA experience. Treat it as the source of truth for user-facing copy and
+  behavior whenever you validate changes locally.
 
 - **Framework:** Next.js 14 (App Router) with React 18 and TypeScript in strict
   mode.


### PR DESCRIPTION
## Summary
- add a Live App section in the README that links to https://www.checkplanner.com
- mention the production domain in the project guide so collaborators reference the deployed PWA

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e494434e64832cbd22e4daceba0d83