### PR TITLE
docs: clarify component presentation and hook pattern

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,15 +1,18 @@
 # CheckPlanner – Agent Quick Guide
 
 ## Project overview
+
 - Personal planner, local-first PWA, fully offline, no backend or env vars.
 
 ## Build and test commands
+
 - Install dependencies: `npm install`
 - Run dev server: `npm run dev`
 - Build for production: `npm run build`
 - Execute tests: `npm run test`
 
 ## Quality gates (must pass)
+
 - Lint (sin warnings)
 - Typecheck
 - Tests
@@ -18,18 +21,38 @@
 If any of these fail, do not open or update a PR. Fix first.
 
 ## Code style guidelines
-- Write TypeScript and follow ESLint + Prettier (Tailwind plugin included); keep formatting clean and adhere to Conventional Commits.
+
+- Write TypeScript and follow ESLint + Prettier (Tailwind plugin included); keep
+  formatting clean and adhere to Conventional Commits.
+- Structure components using the presentational + hook pattern. Keep the UI file
+  focused on markup and styling, move state/actions into a colocated hook that
+  returns the data needed by the component, and extract heavy logic into
+  `_helpers/` with dedicated tests when it becomes complex. Place component and
+  helper tests under their respective `__tests__/` directories.
 
 ## Testing instructions
-- Run `npm run test` for unit/component coverage with Jest + Testing Library; ensure key views render, drag-and-drop flows work, and basic accessibility expectations hold.
+
+- Run `npm run test` for unit/component coverage with Jest + Testing Library;
+  ensure key views render, drag-and-drop flows work, and basic accessibility
+  expectations hold.
 
 ## Security considerations
-- Persist only local data (localStorage), never add backend calls, env vars, or tracking; avoid leaking personal information and follow general client-side security hygiene.
+
+- Persist only local data (localStorage), never add backend calls, env vars, or
+  tracking; avoid leaking personal information and follow general client-side
+  security hygiene.
 
 ## Branch / PR / Commit strategy
-- Branches: English kebab-case with prefixes (`feature/`, `bugfix/`, `hotfix/`, `docs/`); optionally prepend issue IDs (e.g., `feature/123-natural-language-input`).
-- Flow: branch from `main`, keep PRs focused and small, and avoid direct commits to `main`.
-- PRs: follow Conventional Commit messaging, include clear summaries with referenced issues, prefer Squash & merge, and attach UI screenshots when you change the interface.
-- Reviews: use Draft for WIP, rebase/merge with `main` often, and ensure required checks pass before requesting review.
+
+- Branches: English kebab-case with prefixes (`feature/`, `bugfix/`, `hotfix/`,
+  `docs/`); optionally prepend issue IDs (e.g.,
+  `feature/123-natural-language-input`).
+- Flow: branch from `main`, keep PRs focused and small, and avoid direct commits
+  to `main`.
+- PRs: follow Conventional Commit messaging, include clear summaries with
+  referenced issues, prefer Squash & merge, and attach UI screenshots when you
+  change the interface.
+- Reviews: use Draft for WIP, rebase/merge with `main` often, and ensure
+  required checks pass before requesting review.
 
 Agents must adhere to these rules.

--- a/docs/PROJECT_GUIDE.md
+++ b/docs/PROJECT_GUIDE.md
@@ -3,14 +3,14 @@
 ## Purpose of this document
 
 Use this handbook as the single source of truth when you collaborate with the
-CheckPlanner codebase. It summarizes the architecture, data flows,
-quality gates, and conventions that every agent must follow to keep the project
-healthy and scalable.
+CheckPlanner codebase. It summarizes the architecture, data flows, quality
+gates, and conventions that every agent must follow to keep the project healthy
+and scalable.
 
 ## How to use this guide
 
-1. Keep this guide in the `docs/` directory so every collaborator and
-   automation tool can locate it instantly.
+1. Keep this guide in the `docs/` directory so every collaborator and automation
+   tool can locate it instantly.
 2. Ensure the sections remain focused on the information agents need to work
    effectively—project overview, build and test commands, code style rules,
    testing guidance, security considerations, and any other context that aids
@@ -107,6 +107,14 @@ existing helpers so SSR remains safe.
 - When introducing new actions or notifications, surface them through the store
   so `TaskTimerManager`, `RecurringTaskManager`, and `WorkScheduleManager` can
   react appropriately.
+- Follow the component pattern that separates presentation and logic. Each
+  component exposes its UI while delegating state and behavior to a colocated
+  hook (for example `components/Foo/Foo.tsx` uses `useFoo.ts`). The hook returns
+  `{ state, actions }` (or similarly named objects) that the component consumes.
+  If the hook’s logic grows complex, extract helper functions to
+  `components/Foo/_helpers/*.ts` and add targeted tests either in
+  `components/Foo/__tests__` or `components/Foo/_helpers/__tests__` to keep the
+  codebase modular and well covered.
 
 ## Internationalization requirements
 


### PR DESCRIPTION
## Summary
- add the presentational plus hook component pattern to the agent guide
- document hook, helper, and testing expectations in the project guide

## Testing
- n/a (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e4961dcd08832c8457ac42562db4bf