### PR TITLE
refactor: enforce hook state-actions convention

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -26,8 +26,9 @@ If any of these fail, do not open or update a PR. Fix first.
   formatting clean and adhere to Conventional Commits.
 - Structure components using the presentational + hook pattern. Keep the UI file
   focused on markup and styling, move state/actions into a colocated hook that
-  returns the data needed by the component, and extract heavy logic into
-  `_helpers/` with dedicated tests when it becomes complex. Place component and
+  returns only two top-level keys—`state` for data (including refs, ids, and
+  derived values) and `actions` for callable handlers—and extract heavy logic
+  into `_helpers/` with dedicated tests when it becomes complex. Place component and
   helper tests under their respective `__tests__/` directories.
 
 ## Testing instructions

--- a/components/Accordion/Accordion.tsx
+++ b/components/Accordion/Accordion.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
+import useAccordion from './useAccordion';
 
 export interface AccordionItem {
   question: string;
@@ -9,11 +9,10 @@ export interface AccordionItem {
 }
 
 export default function Accordion({ items }: { items: AccordionItem[] }) {
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
-
-  const toggle = (index: number) => {
-    setOpenIndex(prev => (prev === index ? null : index));
-  };
+  const {
+    state: { openIndex },
+    actions: { toggle },
+  } = useAccordion();
 
   return (
     <div className="divide-y overflow-hidden rounded border shadow-sm">

--- a/components/Accordion/useAccordion.ts
+++ b/components/Accordion/useAccordion.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+export default function useAccordion(initialIndex: number | null = null) {
+  const [openIndex, setOpenIndex] = useState<number | null>(initialIndex);
+
+  const toggle = useCallback((index: number) => {
+    setOpenIndex(prev => (prev === index ? null : index));
+  }, []);
+
+  return {
+    state: {
+      openIndex,
+    },
+    actions: {
+      toggle,
+    },
+  } as const;
+}

--- a/components/AddTask/__tests__/AddTask.test.tsx
+++ b/components/AddTask/__tests__/AddTask.test.tsx
@@ -1,10 +1,15 @@
 import { render, screen, fireEvent } from '../../../test/test-utils';
 import AddTask from '../AddTask';
 import useAddTask from '../useAddTask';
+import useAddTaskView from '../useAddTaskView';
 
 jest.mock('../useAddTask');
+jest.mock('../useAddTaskView');
 
 const mockUseAddTask = useAddTask as jest.MockedFunction<typeof useAddTask>;
+const mockUseAddTaskView = useAddTaskView as jest.MockedFunction<
+  typeof useAddTaskView
+>;
 
 describe('AddTask', () => {
   beforeEach(() => {
@@ -25,6 +30,21 @@ describe('AddTask', () => {
         removeTag: jest.fn(),
       },
     });
+    mockUseAddTaskView.mockReturnValue({
+      state: {
+        isListening: false,
+        showVoiceWarning: false,
+        voiceWarningRef: { current: null },
+        voiceWarningCloseButtonRef: { current: null },
+      },
+      actions: {
+        handleVoiceInput: jest.fn(),
+        closeVoiceWarning: jest.fn(),
+        getTagColor: jest.fn(),
+        onVoiceWarningFocusStartGuard: jest.fn(),
+        onVoiceWarningFocusEndGuard: jest.fn(),
+      },
+    } as any);
   });
 
   it('calls handleAdd on submit', () => {

--- a/components/AddTask/useAddTaskView.ts
+++ b/components/AddTask/useAddTaskView.ts
@@ -1,0 +1,151 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Language } from '../../lib/i18n';
+import { Tag } from '../../lib/types';
+import useDialogFocusTrap from '../../lib/useDialogFocusTrap';
+
+interface Options {
+  title: string;
+  setTitle: (value: string | ((prev: string) => string)) => void;
+  existingTags: Tag[];
+  language: Language;
+}
+
+type SpeechRecognitionInstance = {
+  lang: string;
+  start: () => void;
+  stop: () => void;
+  interimResults: boolean;
+  onresult:
+    | ((event: { results: ArrayLike<{ 0: { transcript: string } }> }) => void)
+    | null;
+  onspeechend: (() => void) | null;
+  onend: (() => void) | null;
+};
+
+const SPEECH_LANGUAGE_MAP: Record<Language, string> = {
+  en: 'en-US',
+  es: 'es-ES',
+};
+
+export default function useAddTaskView({
+  title,
+  setTitle,
+  existingTags,
+  language,
+}: Options) {
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+  const titleRef = useRef(title);
+  const initialTitleRef = useRef('');
+  const [isListening, setIsListening] = useState(false);
+  const [showVoiceWarning, setShowVoiceWarning] = useState(false);
+  const voiceWarningRef = useRef<HTMLDivElement | null>(null);
+  const voiceWarningCloseButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    titleRef.current = title;
+  }, [title]);
+
+  const getSpeechRecognition = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    const SpeechRecognitionConstructor =
+      (
+        window as unknown as {
+          SpeechRecognition?: new () => SpeechRecognitionInstance;
+        }
+      ).SpeechRecognition ??
+      (
+        window as unknown as {
+          webkitSpeechRecognition?: new () => SpeechRecognitionInstance;
+        }
+      ).webkitSpeechRecognition ??
+      null;
+
+    if (!SpeechRecognitionConstructor) {
+      return null;
+    }
+
+    if (!recognitionRef.current) {
+      const recognition = new SpeechRecognitionConstructor();
+      recognition.interimResults = false;
+      recognition.onresult = event => {
+        const transcript = event.results[0][0].transcript;
+        setTitle(prev => (prev ? `${prev} ${transcript}` : transcript));
+        recognition.stop();
+      };
+      recognition.onspeechend = () => {
+        recognition.stop();
+      };
+      recognition.onend = () => {
+        setIsListening(false);
+        if (initialTitleRef.current === titleRef.current) {
+          setShowVoiceWarning(true);
+        }
+      };
+      recognitionRef.current = recognition;
+    }
+
+    return recognitionRef.current;
+  }, [setTitle]);
+
+  const handleVoiceInput = useCallback(() => {
+    const recognition = getSpeechRecognition();
+
+    if (!recognition) {
+      return;
+    }
+
+    recognition.lang = SPEECH_LANGUAGE_MAP[language] || language;
+
+    setIsListening(prev => {
+      if (prev) {
+        recognition.stop();
+        return false;
+      }
+
+      setShowVoiceWarning(false);
+      initialTitleRef.current = titleRef.current;
+      recognition.start();
+      return true;
+    });
+  }, [getSpeechRecognition, language]);
+
+  const closeVoiceWarning = useCallback(() => {
+    setShowVoiceWarning(false);
+  }, []);
+
+  const getTagColor = useCallback(
+    (tagLabel: string) => {
+      const tag = existingTags.find(t => t.label === tagLabel);
+      return tag ? tag.color : '#ccc';
+    },
+    [existingTags]
+  );
+
+  const {
+    onFocusStartGuard: onVoiceWarningFocusStartGuard,
+    onFocusEndGuard: onVoiceWarningFocusEndGuard,
+  } = useDialogFocusTrap(showVoiceWarning, voiceWarningRef, {
+    initialFocusRef: voiceWarningCloseButtonRef,
+  });
+
+  return {
+    state: {
+      isListening,
+      showVoiceWarning,
+      voiceWarningRef,
+      voiceWarningCloseButtonRef,
+    },
+    actions: {
+      handleVoiceInput,
+      closeVoiceWarning,
+      getTagColor,
+      onVoiceWarningFocusStartGuard,
+      onVoiceWarningFocusEndGuard,
+    },
+  } as const;
+}

--- a/components/Board/Board.tsx
+++ b/components/Board/Board.tsx
@@ -5,10 +5,9 @@ import TaskCard from '../TaskCard/TaskCard';
 import useBoard, { UseBoardProps } from './useBoard';
 
 export default function Board(props: UseBoardProps) {
-  const { state, actions, helpers } = useBoard(props);
-  const { sensors, activeTask, columns } = state;
+  const { state, actions } = useBoard(props);
+  const { sensors, activeTask, columns, collisionDetection } = state;
   const { getTasks, handleDragStart, handleDragOver, handleDragEnd } = actions;
-  const { closestCorners } = helpers;
 
   const scrollContainerClasses =
     props.mode === 'my-day'
@@ -18,7 +17,7 @@ export default function Board(props: UseBoardProps) {
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={closestCorners}
+      collisionDetection={collisionDetection}
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}

--- a/components/Board/__tests__/Board.test.tsx
+++ b/components/Board/__tests__/Board.test.tsx
@@ -18,6 +18,7 @@ describe('Board', () => {
           { id: 'c1', title: 'Col1' },
           { id: 'c2', title: 'Col2' },
         ],
+        collisionDetection: jest.fn(),
       },
       actions: {
         getTasks: () => [],
@@ -25,7 +26,6 @@ describe('Board', () => {
         handleDragOver: jest.fn(),
         handleDragEnd: jest.fn(),
       },
-      helpers: { closestCorners: jest.fn() },
     });
 
     render(<Board mode="my-day" />);

--- a/components/Board/useBoard.ts
+++ b/components/Board/useBoard.ts
@@ -126,8 +126,12 @@ export default function useBoard({ mode }: UseBoardProps) {
   };
 
   return {
-    state: { sensors, activeTask, columns },
+    state: {
+      sensors,
+      activeTask,
+      columns,
+      collisionDetection: closestCorners,
+    },
     actions: { getTasks, handleDragStart, handleDragOver, handleDragEnd },
-    helpers: { closestCorners },
   } as const;
 }

--- a/components/NotificationCard/NotificationCard.tsx
+++ b/components/NotificationCard/NotificationCard.tsx
@@ -1,118 +1,62 @@
 'use client';
 
-import type { ReactNode } from 'react';
 import Link from 'next/link';
-import {
-  Info,
-  AlertTriangle,
-  Lightbulb,
-  MonitorSmartphone,
-  LayoutTemplate,
-  X,
-} from 'lucide-react';
-import { useI18n } from '../../lib/i18n';
+import { MonitorSmartphone, LayoutTemplate, X } from 'lucide-react';
 import { Notification } from '../../lib/types';
-import { useStore } from '../../lib/store';
-import { getNotificationIconClasses } from '../../lib/notifications';
-import { usePwaInstallPrompt } from '../../lib/usePwaInstallPrompt';
+import useNotificationCard, {
+  type NotificationAction,
+} from './useNotificationCard';
 
 interface Props {
   notification: Notification;
 }
 
 export default function NotificationCard({ notification }: Props) {
-  const { t } = useI18n();
-  const removeNotification = useStore(state => state.removeNotification);
-  const { canInstall, isInstalled, promptInstall } = usePwaInstallPrompt();
-  const Icon =
-    notification.type === 'alert'
-      ? AlertTriangle
-      : notification.type === 'tip'
-        ? Lightbulb
-        : Info;
-  const title = notification.title ?? t(notification.titleKey);
-  const description =
-    notification.description ?? t(notification.descriptionKey);
-  const dismissLabel = t('notifications.dismiss');
-  const actions: { key: string; node: ReactNode }[] = [];
-  const installDisabled = isInstalled || !canInstall;
-  const installTitle = isInstalled
-    ? t('notifications.welcome.installInstalled')
-    : !canInstall
-      ? t('notifications.welcome.installUnavailable')
-      : undefined;
+  const {
+    state: {
+      icon: Icon,
+      iconClassName,
+      title,
+      description,
+      dismissLabel,
+      isWelcomeNotification,
+      actionItems,
+    },
+    actions: { handleDismiss },
+  } = useNotificationCard({ notification });
+
   const primaryActionClasses =
     'inline-flex items-center justify-center gap-2 rounded bg-[#57886C] px-3 py-2 text-sm font-semibold text-white transition hover:brightness-110 focus:outline-none focus:ring focus:ring-offset-2 focus:ring-[#57886C] disabled:cursor-not-allowed disabled:opacity-60';
   const secondaryActionClasses =
     'inline-flex items-center justify-center gap-2 rounded bg-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 transition hover:bg-gray-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:outline-gray-600';
 
-  const isWelcomeNotification = notification.id === 'welcome';
+  const getActionClasses = (action: NotificationAction) => {
+    return action.variant === 'primary'
+      ? primaryActionClasses
+      : secondaryActionClasses;
+  };
 
-  if (isWelcomeNotification) {
-    actions.push({
-      key: 'demo',
-      node: (
-        <Link
-          href="/demo-templates"
-          className={secondaryActionClasses}
-        >
-          <LayoutTemplate
-            className="h-4 w-4"
-            aria-hidden="true"
-          />
-          {t('notifications.welcome.demoCta')}
-        </Link>
-      ),
-    });
+  const renderActionIcon = (action: NotificationAction) => {
+    if (action.icon === 'layout-template') {
+      return (
+        <LayoutTemplate
+          className="h-4 w-4"
+          aria-hidden="true"
+        />
+      );
+    }
 
-    actions.push({
-      key: 'install',
-      node: (
-        <button
-          type="button"
-          onClick={() => {
-            if (!installDisabled) {
-              void promptInstall();
-            }
-          }}
-          disabled={installDisabled}
-          title={installTitle}
-          className={primaryActionClasses}
-        >
-          <MonitorSmartphone
-            className="h-4 w-4"
-            aria-hidden="true"
-          />
-          {t('notifications.welcome.installCta')}
-        </button>
-      ),
-    });
-  }
+    if (action.icon === 'monitor-smartphone') {
+      return (
+        <MonitorSmartphone
+          className="h-4 w-4"
+          aria-hidden="true"
+        />
+      );
+    }
 
-  if (notification.actionUrl && notification.actionLabelKey) {
-    const isInternalAction = notification.actionUrl.startsWith('/');
-
-    actions.push({
-      key: 'action',
-      node: isInternalAction ? (
-        <Link
-          href={notification.actionUrl}
-          className={primaryActionClasses}
-        >
-          {t(notification.actionLabelKey)}
-        </Link>
-      ) : (
-        <a
-          href={notification.actionUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={primaryActionClasses}
-        >
-          {t(notification.actionLabelKey)}
-        </a>
-      ),
-    });
-  }
+    return null;
+  };
 
   return (
     <div className="relative overflow-hidden rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition hover:border-blue-200 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-blue-700/60">
@@ -121,7 +65,7 @@ export default function NotificationCard({ notification }: Props) {
           type="button"
           aria-label={dismissLabel}
           title={dismissLabel}
-          onClick={() => removeNotification(notification.id)}
+          onClick={handleDismiss}
           className="absolute right-4 top-4 rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
         >
           <X
@@ -132,7 +76,7 @@ export default function NotificationCard({ notification }: Props) {
       )}
       <div className="flex items-start gap-4">
         <Icon
-          className={`mt-1 h-6 w-6 flex-shrink-0 ${getNotificationIconClasses(notification.type)}`}
+          className={`mt-1 h-6 w-6 flex-shrink-0 ${iconClassName}`}
           aria-hidden="true"
         />
         <div className="flex-1 space-y-3 pr-8">
@@ -142,14 +86,43 @@ export default function NotificationCard({ notification }: Props) {
           <p className="text-base leading-relaxed text-gray-700 break-words dark:text-gray-200">
             {description}
           </p>
-          {actions.length > 0 && (
+          {actionItems.length > 0 && (
             <div className="mt-3 flex flex-wrap justify-end gap-2">
-              {actions.map(action => (
+              {actionItems.map(action => (
                 <span
                   key={action.key}
                   className="inline-flex"
                 >
-                  {action.node}
+                  {action.type === 'button' ? (
+                    <button
+                      type="button"
+                      onClick={action.onClick}
+                      disabled={action.disabled}
+                      title={action.title}
+                      className={getActionClasses(action)}
+                    >
+                      {renderActionIcon(action)}
+                      {action.label}
+                    </button>
+                  ) : action.type === 'link' ? (
+                    <Link
+                      href={action.href}
+                      className={getActionClasses(action)}
+                    >
+                      {renderActionIcon(action)}
+                      {action.label}
+                    </Link>
+                  ) : (
+                    <a
+                      href={action.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={getActionClasses(action)}
+                    >
+                      {renderActionIcon(action)}
+                      {action.label}
+                    </a>
+                  )}
                 </span>
               ))}
             </div>

--- a/components/NotificationCard/__tests__/useNotificationCard.test.ts
+++ b/components/NotificationCard/__tests__/useNotificationCard.test.ts
@@ -1,0 +1,75 @@
+import { renderHook, act } from '@testing-library/react';
+import useNotificationCard from '../useNotificationCard';
+import { useStore } from '../../../lib/store';
+import { usePwaInstallPrompt } from '../../../lib/usePwaInstallPrompt';
+
+jest.mock('../../../lib/usePwaInstallPrompt');
+
+const mockUsePwaInstallPrompt = usePwaInstallPrompt as jest.MockedFunction<
+  typeof usePwaInstallPrompt
+>;
+
+const initialState = useStore.getState();
+
+describe('useNotificationCard', () => {
+  beforeEach(() => {
+    act(() => {
+      useStore.setState(initialState, true);
+    });
+    mockUsePwaInstallPrompt.mockReturnValue({
+      canInstall: false,
+      isInstalled: false,
+      promptInstall: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      useStore.setState(initialState, true);
+    });
+  });
+
+  it('returns welcome actions', () => {
+    const { result } = renderHook(() =>
+      useNotificationCard({
+        notification: {
+          id: 'welcome',
+          type: 'info',
+          titleKey: 'notifications.welcome.title',
+          descriptionKey: 'notifications.welcome.description',
+          read: false,
+          createdAt: new Date().toISOString(),
+        },
+      })
+    );
+
+    expect(result.current.state.isWelcomeNotification).toBe(true);
+    expect(result.current.state.actionItems).toHaveLength(2);
+  });
+
+  it('dismisses notifications', () => {
+    const removeNotification = jest.fn();
+    act(() => {
+      useStore.setState({ removeNotification });
+    });
+
+    const { result } = renderHook(() =>
+      useNotificationCard({
+        notification: {
+          id: 'test',
+          type: 'info',
+          titleKey: 'notifications.welcome.title',
+          descriptionKey: 'notifications.welcome.description',
+          read: false,
+          createdAt: new Date().toISOString(),
+        },
+      })
+    );
+
+    act(() => {
+      result.current.actions.handleDismiss();
+    });
+
+    expect(removeNotification).toHaveBeenCalledWith('test');
+  });
+});

--- a/components/NotificationCard/useNotificationCard.ts
+++ b/components/NotificationCard/useNotificationCard.ts
@@ -1,0 +1,146 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { AlertTriangle, Info, Lightbulb, type LucideIcon } from 'lucide-react';
+import { useI18n } from '../../lib/i18n';
+import { Notification } from '../../lib/types';
+import { useStore } from '../../lib/store';
+import { getNotificationIconClasses } from '../../lib/notifications';
+import { usePwaInstallPrompt } from '../../lib/usePwaInstallPrompt';
+
+export type NotificationAction =
+  | {
+      key: string;
+      type: 'link' | 'external-link';
+      href: string;
+      label: string;
+      variant: 'primary' | 'secondary';
+      icon?: 'layout-template';
+    }
+  | {
+      key: string;
+      type: 'button';
+      label: string;
+      variant: 'primary' | 'secondary';
+      icon?: 'monitor-smartphone';
+      disabled?: boolean;
+      title?: string;
+      onClick: () => void;
+    };
+
+interface Options {
+  notification: Notification;
+}
+
+export default function useNotificationCard({ notification }: Options) {
+  const removeNotification = useStore(state => state.removeNotification);
+  const { t } = useI18n();
+  const { canInstall, isInstalled, promptInstall } = usePwaInstallPrompt();
+
+  const icon: LucideIcon = useMemo(() => {
+    if (notification.type === 'alert') {
+      return AlertTriangle;
+    }
+
+    if (notification.type === 'tip') {
+      return Lightbulb;
+    }
+
+    return Info;
+  }, [notification.type]);
+
+  const title = notification.title ?? t(notification.titleKey);
+  const description =
+    notification.description ?? t(notification.descriptionKey);
+  const dismissLabel = t('notifications.dismiss');
+  const iconClassName = getNotificationIconClasses(notification.type);
+  const isWelcomeNotification = notification.id === 'welcome';
+
+  const handleDismiss = useCallback(() => {
+    removeNotification(notification.id);
+  }, [notification.id, removeNotification]);
+
+  const installDisabled = isInstalled || !canInstall;
+  const installTitle = isInstalled
+    ? t('notifications.welcome.installInstalled')
+    : !canInstall
+      ? t('notifications.welcome.installUnavailable')
+      : undefined;
+
+  const actionItems: NotificationAction[] = useMemo(() => {
+    const items: NotificationAction[] = [];
+
+    if (isWelcomeNotification) {
+      items.push({
+        key: 'demo',
+        type: 'link',
+        href: '/demo-templates',
+        label: t('notifications.welcome.demoCta'),
+        variant: 'secondary',
+        icon: 'layout-template',
+      });
+
+      items.push({
+        key: 'install',
+        type: 'button',
+        label: t('notifications.welcome.installCta'),
+        variant: 'primary',
+        icon: 'monitor-smartphone',
+        disabled: installDisabled,
+        title: installTitle,
+        onClick: () => {
+          if (!installDisabled) {
+            void promptInstall();
+          }
+        },
+      });
+    }
+
+    if (notification.actionUrl && notification.actionLabelKey) {
+      const baseAction = {
+        key: 'action',
+        label: t(notification.actionLabelKey),
+        variant: 'primary' as const,
+      };
+
+      if (notification.actionUrl.startsWith('/')) {
+        items.push({
+          ...baseAction,
+          type: 'link',
+          href: notification.actionUrl,
+        });
+      } else {
+        items.push({
+          ...baseAction,
+          type: 'external-link',
+          href: notification.actionUrl,
+        });
+      }
+    }
+
+    return items;
+  }, [
+    installDisabled,
+    installTitle,
+    isWelcomeNotification,
+    notification.actionLabelKey,
+    notification.actionUrl,
+    promptInstall,
+    t,
+  ]);
+
+  return {
+    state: {
+      icon,
+      iconClassName,
+      title,
+      description,
+      dismissLabel,
+      isWelcomeNotification,
+      actionItems,
+    },
+    actions: {
+      handleDismiss,
+    },
+  } as const;
+}

--- a/components/TasksView/TasksView.tsx
+++ b/components/TasksView/TasksView.tsx
@@ -1,12 +1,11 @@
 'use client';
-import { useEffect, useId, useRef, useState } from 'react';
 import { Plus } from 'lucide-react';
 import AddTask from '../AddTask/AddTask';
 import TaskList from '../TaskList/TaskList';
 import TagFilter from '../TagFilter/TagFilter';
 import useTasksView from './useTasksView';
 import { useI18n } from '../../lib/i18n';
-import useDialogFocusTrap from '../../lib/useDialogFocusTrap';
+import useTasksViewLayout from './useTasksViewLayout';
 
 export default function TasksView() {
   const { state, actions } = useTasksView();
@@ -30,45 +29,20 @@ export default function TasksView() {
     cancelRemoveTag,
   } = actions;
   const { t } = useI18n();
-  const [showMobileAddTask, setShowMobileAddTask] = useState(!hasTasks);
-  const confirmDialogRef = useRef<HTMLDivElement | null>(null);
-  const confirmCancelButtonRef = useRef<HTMLButtonElement | null>(null);
-  const confirmDeleteTitleId = useId();
-  const confirmDeleteDescriptionId = useId();
-  const { onFocusStartGuard, onFocusEndGuard } = useDialogFocusTrap(
-    Boolean(tagToRemove),
-    confirmDialogRef,
-    { initialFocusRef: confirmCancelButtonRef }
-  );
-
-  useEffect(() => {
-    if (!hasTasks) {
-      setShowMobileAddTask(true);
-    }
-  }, [hasTasks]);
-
-  useEffect(() => {
-    if (!tagToRemove) {
-      return undefined;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        cancelRemoveTag();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [tagToRemove, cancelRemoveTag]);
-
-  const showMobileForm = () => {
-    setShowMobileAddTask(true);
-  };
+  const {
+    state: {
+      showMobileAddTask,
+      confirmDialogRef,
+      confirmCancelButtonRef,
+      confirmDeleteTitleId,
+      confirmDeleteDescriptionId,
+    },
+    actions: { showMobileForm, onFocusStartGuard, onFocusEndGuard },
+  } = useTasksViewLayout({
+    hasTasks,
+    tagToRemove,
+    cancelRemoveTag,
+  });
   return (
     <main>
       {hasTasks && !showMobileAddTask && (

--- a/components/TasksView/useTasksViewLayout.ts
+++ b/components/TasksView/useTasksViewLayout.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import useDialogFocusTrap from '../../lib/useDialogFocusTrap';
+
+interface Options {
+  hasTasks: boolean;
+  tagToRemove: string | null;
+  cancelRemoveTag: () => void;
+}
+
+export default function useTasksViewLayout({
+  hasTasks,
+  tagToRemove,
+  cancelRemoveTag,
+}: Options) {
+  const [showMobileAddTask, setShowMobileAddTask] = useState(!hasTasks);
+  const confirmDialogRef = useRef<HTMLDivElement | null>(null);
+  const confirmCancelButtonRef = useRef<HTMLButtonElement | null>(null);
+  const confirmDeleteTitleId = useId();
+  const confirmDeleteDescriptionId = useId();
+
+  useEffect(() => {
+    if (!hasTasks) {
+      setShowMobileAddTask(true);
+    }
+  }, [hasTasks]);
+
+  useEffect(() => {
+    if (!tagToRemove) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelRemoveTag();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [tagToRemove, cancelRemoveTag]);
+
+  const showMobileForm = useCallback(() => {
+    setShowMobileAddTask(true);
+  }, []);
+
+  const { onFocusStartGuard, onFocusEndGuard } = useDialogFocusTrap(
+    Boolean(tagToRemove),
+    confirmDialogRef,
+    { initialFocusRef: confirmCancelButtonRef }
+  );
+
+  return {
+    state: {
+      showMobileAddTask,
+      confirmDialogRef,
+      confirmCancelButtonRef,
+      confirmDeleteTitleId,
+      confirmDeleteDescriptionId,
+    },
+    actions: {
+      showMobileForm,
+      onFocusStartGuard,
+      onFocusEndGuard,
+    },
+  } as const;
+}

--- a/components/WelcomeModal/WelcomeModal.tsx
+++ b/components/WelcomeModal/WelcomeModal.tsx
@@ -1,39 +1,15 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
 import { Check } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import { useStore } from '../../lib/store';
 import { useI18n } from '../../lib/i18n';
-import useDialogFocusTrap from '../../lib/useDialogFocusTrap';
+import useWelcomeModal from './useWelcomeModal';
 
 export default function WelcomeModal() {
-  const [open, setOpen] = useState(false);
-  const tasks = useStore(state => state.tasks);
-  const router = useRouter();
+  const {
+    state: { open, checklistItems, dialogRef, primaryButtonRef },
+    actions: { handleClose, onFocusStartGuard, onFocusEndGuard },
+  } = useWelcomeModal();
   const { t } = useI18n();
-  const dialogRef = useRef<HTMLDivElement | null>(null);
-  const primaryButtonRef = useRef<HTMLButtonElement | null>(null);
-  const { onFocusStartGuard, onFocusEndGuard } = useDialogFocusTrap(
-    open,
-    dialogRef,
-    {
-      initialFocusRef: primaryButtonRef,
-    }
-  );
-
-  useEffect(() => {
-    const seen = localStorage.getItem('welcomeSeen');
-    if (!seen && tasks.length === 0) {
-      setOpen(true);
-    }
-  }, [tasks]);
-
-  const handleClose = () => {
-    localStorage.setItem('welcomeSeen', '1');
-    setOpen(false);
-    router.push('/my-tasks');
-  };
 
   if (!open) return null;
 
@@ -60,7 +36,7 @@ export default function WelcomeModal() {
           {t('welcomeModal.title')}
         </h2>
         <ul className="mb-6 space-y-2">
-          {[1, 2, 3, 4, 5].map(n => (
+          {checklistItems.map(n => (
             <li
               key={n}
               className="flex items-start gap-2"

--- a/components/WelcomeModal/useWelcomeModal.ts
+++ b/components/WelcomeModal/useWelcomeModal.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useStore } from '../../lib/store';
+import useDialogFocusTrap from '../../lib/useDialogFocusTrap';
+
+export default function useWelcomeModal() {
+  const [open, setOpen] = useState(false);
+  const tasks = useStore(state => state.tasks);
+  const router = useRouter();
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const primaryButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    const seen =
+      typeof window !== 'undefined'
+        ? window.localStorage.getItem('welcomeSeen')
+        : null;
+
+    if (!seen && tasks.length === 0) {
+      setOpen(true);
+    }
+  }, [tasks]);
+
+  const handleClose = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('welcomeSeen', '1');
+    }
+    setOpen(false);
+    router.push('/my-tasks');
+  }, [router]);
+
+  const checklistItems = [1, 2, 3, 4, 5] as const;
+
+  const { onFocusStartGuard, onFocusEndGuard } = useDialogFocusTrap(
+    open,
+    dialogRef,
+    {
+      initialFocusRef: primaryButtonRef,
+    }
+  );
+
+  return {
+    state: {
+      open,
+      checklistItems,
+      dialogRef,
+      primaryButtonRef,
+    },
+    actions: {
+      handleClose,
+      onFocusStartGuard,
+      onFocusEndGuard,
+    },
+  } as const;
+}

--- a/docs/PROJECT_GUIDE.md
+++ b/docs/PROJECT_GUIDE.md
@@ -113,12 +113,13 @@ existing helpers so SSR remains safe.
   react appropriately.
 - Follow the component pattern that separates presentation and logic. Each
   component exposes its UI while delegating state and behavior to a colocated
-  hook (for example `components/Foo/Foo.tsx` uses `useFoo.ts`). The hook returns
-  `{ state, actions }` (or similarly named objects) that the component consumes.
-  If the hook’s logic grows complex, extract helper functions to
-  `components/Foo/_helpers/*.ts` and add targeted tests either in
-  `components/Foo/__tests__` or `components/Foo/_helpers/__tests__` to keep the
-  codebase modular and well covered.
+  hook (for example `components/Foo/Foo.tsx` uses `useFoo.ts`). The hook must
+  return exactly two top-level keys: `state` (for any data, refs, ids, or
+  derived values) and `actions` (for callable handlers). If the hook’s logic
+  grows complex, extract helper functions to `components/Foo/_helpers/*.ts` and
+  add targeted tests either in `components/Foo/__tests__` or
+  `components/Foo/_helpers/__tests__` to keep the codebase modular and well
+  covered.
 
 ## Internationalization requirements
 


### PR DESCRIPTION
## Summary
- align component hooks to expose only state and actions while updating consuming components and tests
- document the hook contract in AGENTS.MD and the project guide to clarify the pattern

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e49f8df05c832c959ab8cea1fd0cf7